### PR TITLE
End game when hints are exhausted

### DIFF
--- a/components/pokemon-shiritori-game.tsx
+++ b/components/pokemon-shiritori-game.tsx
@@ -137,6 +137,21 @@ export function PokemonShiritoriGame() {
     }
   }, [chain])
 
+  // 候補が存在しない場合は自動的にゲームオーバー
+  useEffect(() => {
+    if (gameState !== "playing") return
+    if (!nextChar) return
+
+    const candidate = getPokemonByFirstChar(pokemonDatabase, nextChar, usedNames, DAKUTEN_MAP)
+    if (!candidate) {
+      setMessage("💥 出せるポケモンがありません。ゲームオーバー")
+      setHighScore(saveHighScore(score, highScore))
+      setGameState("finished")
+      setShowEndConfirm(false)
+      setShowResultModal(true)
+    }
+  }, [gameState, nextChar, usedNames, pokemonDatabase, score, highScore])
+
   const getRandomChar = () => {
     const randomIndex = Math.floor(Math.random() * KATAKANA_LIST.length)
     return KATAKANA_LIST[randomIndex]

--- a/components/pokemon-shiritori-game.tsx
+++ b/components/pokemon-shiritori-game.tsx
@@ -303,7 +303,11 @@ export function PokemonShiritoriGame() {
       setUsedHint(true)
       setMessage(`💡 ヒント: ${hintPokemon.name} -1pt`)
     } else {
-      setMessage(`💡 ヒント: 該当するポケモンが見つかりません`)
+      setMessage(`💡 ヒント: 該当するポケモンが見つかりません。ゲームオーバー`)
+      setHighScore(saveHighScore(score, highScore))
+      setGameState("finished")
+      setShowEndConfirm(false)
+      setShowResultModal(true)
     }
   }
 


### PR DESCRIPTION
End the game as 'game over' when the hint feature cannot find any more candidates.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b75283a-12ae-44a1-b760-3cf952da3fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b75283a-12ae-44a1-b760-3cf952da3fb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> When the hint system finds no candidate, immediately end the game, save high score, and show the result modal with a game-over message.
> 
> - **Game logic (`components/pokemon-shiritori-game.tsx`)**:
>   - In `handleHint`, when `getPokemonByFirstChar` returns no result:
>     - Update message to include game over.
>     - Save high score via `saveHighScore` and set `gameState` to `"finished"`.
>     - Hide end confirmation (`setShowEndConfirm(false)`) and open results (`setShowResultModal(true)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab3a7f6ccb6173df3d94ec3eebd1dbedeac564cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->