### PR TITLE
fix(ci): Pages デプロイを単一路線化し、一過性障害に強くする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,55 +5,91 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # update-stats.yml などから明示起動（GITHUB_TOKEN push では起動されないため）
+  workflow_dispatch:
 
 permissions:
   contents: read
   pages: write
   id-token: write
-  deployments: write
 
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      
+
     - name: Setup pnpm
       uses: pnpm/action-setup@v2
       with:
         version: 8
-        
+
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'pnpm'
-        
+
     - name: Install dependencies
       run: pnpm install
-      
+
     - name: Build
       run: pnpm run build
       env:
         NODE_ENV: production
-        
+
+    # PR ではビルド検証のみ。Pages 成果物の upload / deploy は本番経路だけ。
     - name: Setup Pages
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/configure-pages@v4
-      
+
     - name: Upload artifact
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       uses: actions/upload-pages-artifact@v3
       with:
         path: ./out
-        
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.final.outputs.page_url }}
+
+    steps:
+    # Pages / Actions の一過性障害（503 / "try again later" / timeout）向けに1回だけ再試行
     - name: Deploy to GitHub Pages
       id: deployment
+      continue-on-error: true
       uses: actions/deploy-pages@v4
+
+    - name: Wait before deploy retry
+      if: steps.deployment.outcome == 'failure'
+      run: |
+        echo "⚠️ 初回デプロイが失敗しました。30秒待って再試行します..."
+        sleep 30
+
+    - name: Retry Deploy to GitHub Pages
+      id: deployment-retry
+      if: steps.deployment.outcome == 'failure'
+      uses: actions/deploy-pages@v4
+
+    - name: Resolve deployment URL
+      id: final
+      run: |
+        if [ "${{ steps.deployment.outcome }}" = "success" ]; then
+          echo "page_url=${{ steps.deployment.outputs.page_url }}" >> "$GITHUB_OUTPUT"
+        elif [ "${{ steps.deployment-retry.outcome }}" = "success" ]; then
+          echo "page_url=${{ steps.deployment-retry.outputs.page_url }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "❌ GitHub Pages へのデプロイに失敗しました"
+          exit 1
+        fi
+        echo "🌐 Site URL: $(grep page_url "$GITHUB_OUTPUT" | cut -d= -f2-)"

--- a/.github/workflows/update-stats.yml
+++ b/.github/workflows/update-stats.yml
@@ -4,41 +4,40 @@ on:
   # 3時間ごとに実行（基本統計）
   schedule:
     - cron: '0 */3 * * *'
-  
+
   # 手動実行も可能
   workflow_dispatch:
 
-# GitHub Pagesへのデプロイ権限
+# stats.json のコミットと、変更時の deploy.yml 起動に必要
 permissions:
-  contents: write  # stats.jsonの更新とコミットに必要
-  pages: write
-  id-token: write
+  contents: write
+  actions: write
 
-# 同時実行を防ぐ
+# Pages デプロイとは別グループにし、deploy.yml との競合を避ける
 concurrency:
-  group: "pages"
+  group: "update-stats"
   cancel-in-progress: false
 
 jobs:
-  update-stats-and-deploy:
+  update-stats:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: 📥 Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: 🔧 Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
-        
+
     - name: 📦 Install dependencies
       run: npm ci
-      
+
     - name: 🔄 Update Version File
       run: npm run update-version
-      
+
     - name: 📊 Fetch Analytics Data
       env:
         GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
@@ -51,38 +50,30 @@ jobs:
         echo "🔍 Google Analytics データを取得中..."
         echo "📊 全統計データを取得します（基本統計 + 最高記録 + Pokemon統計）"
         node scripts/fetch-stats.js
-        
+
     - name: 💾 Commit and Push Updated Stats
+      id: commit
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add public/stats.json public/version/version.txt
         if git diff --staged --quiet; then
           echo "📊 統計データに変更はありません"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
         else
           git commit -m "📊 統計データを自動更新 - $(TZ='Asia/Tokyo' date '+%Y-%m-%d %H:%M:%S JST')"
           git push
           echo "✅ 統計データを更新しました"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
         fi
-        
-    - name: 🏗️ Build Next.js application
+
+    # GITHUB_TOKEN による push は他ワークフローを起動しないため、
+    # Pages デプロイは deploy.yml を明示的に dispatch する（単一デプロイ経路）
+    - name: 🚀 Trigger Pages deploy
+      if: steps.commit.outputs.changed == 'true'
       env:
-        NODE_ENV: production
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "🏗️ Next.js アプリケーションをビルド中..."
-        npm run build
-        
-    - name: 📤 Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: ./out
-        
-    - name: 🚀 Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
-      
-    - name: ✅ Deployment Summary
-      run: |
-        echo "🎉 デプロイが完了しました!"
-        echo "📊 統計データが更新されました"
-        echo "🌐 サイトURL: ${{ steps.deployment.outputs.page_url }}"
+        echo "📡 Deploy to GitHub Pages ワークフローを起動します..."
+        gh workflow run "Deploy to GitHub Pages" --ref main
+        echo "✅ デプロイワークフローを起動しました（Pages の実デプロイは deploy.yml のみ）"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 原因

最近の `Update Game Statistics` 失敗はアプリ不具合ではなく、GitHub Pages / Actions 側の一過性障害（`codeload` の 503/429、deploy timeout、`Deployment failed, try again later`、runner 未取得）が主因でした。

加えて構造上の問題として、`update-stats.yml` 自身が Pages にデプロイしたうえで `main` へ push し、同じ concurrency group `pages`（`cancel-in-progress: false`）を `deploy.yml` と共有していました。スケジュール更新と通常 push が重なるとデプロイが待ち行列化し、Pages の不安定さを増幅し得ます。

補足: `GITHUB_TOKEN` による push は通常ほかの workflow を起動しません。実運用ではスケジュール経路の Pages 更新はほぼ `update-stats.yml` 内デプロイに依存していました（`deploy.yml` の直近成功は人手 push 時点）。そのため「デプロイ除去だけ」だと統計更新が Pages に載らなくなるため、変更時は `deploy.yml` を明示 `workflow_dispatch` します。

## 対応

1. **`update-stats.yml`**
   - `upload-pages-artifact` / `deploy-pages` / デプロイ用 summary を削除
   - 不要になった `pages` / `id-token` 権限を削除
   - concurrency group を `update-stats` に分離（`pages` と競合しない）
   - stats に変更があるときだけ `gh workflow run "Deploy to GitHub Pages"` で単一デプロイ経路を起動（`actions: write`）

2. **`deploy.yml`（唯一の Pages デプロイ）**
   - PR: ビルド検証のみ（artifact upload / deploy なし）
   - `push` to `main` と `workflow_dispatch` でのみ deploy
   - `deploy-pages` 失敗時に 30 秒待って 1 回だけ再試行（503 / try again later 向け）
   - Node 18 → 20（EOL 回避、低リスク）

アプリケーションのゲームロジックや GA 取得スクリプトは変更していません。package manager（update-stats=npm / deploy=pnpm）も維持しています。

## 完了条件

- [x] `update-stats` が `deploy-pages` / `upload-pages-artifact` を呼ばない
- [x] Pages デプロイは `deploy.yml` のみ（main push / workflow_dispatch）
- [x] workflow YAML は妥当
- [x] secrets / アプリコードは未変更

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53010fd3-8d79-4107-a9e6-ed4c6bcb027f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53010fd3-8d79-4107-a9e6-ed4c6bcb027f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

